### PR TITLE
Use libusb, Layers' Keycodes, GUI update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ __pypackages__/
 
 # Environments
 venv/
+
+# VSCode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Environments
+venv/

--- a/python/dumang_ctrl/dumang/common.py
+++ b/python/dumang_ctrl/dumang/common.py
@@ -29,7 +29,6 @@ KBD_2_ID = 0x0D
 MAX_KEYS = 256
 UNKNOWN_KEYCODE_STR = "UNKNOWN"
 
-# TODO: This needs to take into account DuMang LT/FN keys.
 class Keycode:
     A = 0x04
     """``a`` and ``A``"""
@@ -289,6 +288,33 @@ class Keycode:
     RIGHT_GUI = 0xE7
     """GUI modifier right of the spacebar"""
 
+    LAYER_0 = 0xD0
+    """Change to keyboard Layer 0""" 
+    LAYER_1 = 0xD1
+    """Change to keyboard Layer 1""" 
+    LAYER_2 = 0xD2
+    """Change to keyboard Layer 2""" 
+    LAYER_3 = 0xD3
+    """Change to keyboard Layer 3"""
+
+    LAYER_TOGGLE_0 = 0xD4
+    """Change while pressing to keyboard Layer 0""" 
+    LAYER_TOGGLE_1 = 0xD5
+    """Change while pressing to keyboard Layer 1""" 
+    LAYER_TOGGLE_2 = 0xD6
+    """Change while pressing to keyboard Layer 2""" 
+    LAYER_TOGGLE_3 = 0xD6
+    """Change while pressing to keyboard Layer 3"""
+
+    LAYER_KEY_0 = 0xDC
+    """Change when long pressing to keyboard Layer 0""" 
+    LAYER_KEY_1 = 0xDD
+    """Change when long pressing to keyboard Layer 1""" 
+    LAYER_KEY_2 = 0xDE
+    """Change when long pressing to keyboard Layer 2""" 
+    LAYER_KEY_3 = 0xDF
+    """Change when long pressing to keyboard Layer 3"""
+    
     def __init__(self, keycode):
         self.keycode = keycode
         self.keystr = UNKNOWN_KEYCODE_STR

--- a/python/dumang_ctrl/dumang/common.py
+++ b/python/dumang_ctrl/dumang/common.py
@@ -661,6 +661,7 @@ class USBConnectionMonitor:
         self.product_id = product_id
         self.notify_q = queue.Queue()
         self._notify_threshold = 2
+        self._has_started = False
 
     def _on_device_left(self, detected_device):
         print('Device left:', str(detected_device))
@@ -703,9 +704,11 @@ class USBConnectionMonitor:
     def _update_status(self):
         total_connected = len(self._device_dict)
         if total_connected == self._notify_threshold:
+            self._has_started = True
             self.ready()
         elif total_connected < self._notify_threshold:
-            self.wait()
+            if(self._has_started):
+                self.wait()
         else:
             raise TooManyBoards(
                 'Too many boards connected. Not sure how to handle it.'

--- a/python/dumang_ctrl/dumang/gui.py
+++ b/python/dumang_ctrl/dumang/gui.py
@@ -20,6 +20,10 @@ class KBDTableView(QTableWidget):
         self.resizeRowsToContents()
         self._last_index = QPersistentModelIndex()
         self.viewport().installEventFilter(self)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.Fixed)
+        self.setSelectionBehavior(QTableView.SelectRows)
 
     def setData(self):
         for n, p in enumerate(self.keys.items()):
@@ -61,33 +65,103 @@ class KBDTableView(QTableWidget):
         p = LightPulsePacket(False, self.keys[int(self.item(item.row(), 0).data(0), 16)])
         kbd.put(p)
 
+class KBDWidget(QWidget):
+    def __init__(self, parent, kbd):
+        super(QWidget, self).__init__(parent)
+        self.layout = QVBoxLayout(self)
+        self.tableWidget = self._add_table_widget(kbd)
+        self.layout.addWidget(self.tableWidget)
+        self.setLayout(self.layout)
+    
+    def _add_table_widget(self, kbd):
+        kbd_widget = KBDTableView(kbd.configured_keys)
+        kbd_widget.setMouseTracking(1)
+        kbd_widget.itemEntered.connect(lambda item: kbd_widget._on_itemEntered(kbd, item))
+        kbd_widget.itemExited.connect(lambda item: kbd_widget._on_itemExited(kbd, item))
+        return kbd_widget
+    
+    def hideLayout(self, n):
+        self.tableWidget.hideColumn(n + 1)
+
+    def showLayout(self, n):
+        self.tableWidget.showColumn(n + 1)
+
+class KBDTab(QWidget):
+    def __init__(self, parent, kbd):
+        super(QWidget, self).__init__(parent)
+        self.layout = QVBoxLayout(self)
+        self.layout.setAlignment(Qt.AlignTop)
+
+        self.kbd_label = QLabel("KBD: " + kbd.serial)
+        self.layout.addWidget(self.kbd_label)
+
+        # Add dropdown/combo box
+        headers = [f'Layout {i}' for i in range(4)]
+        self.comboLayouts = QComboBox()
+        self.comboLayouts.addItems(headers)
+        self.label = QLabel("&L:")
+        self.label.setBuddy(self.comboLayouts)
+        self.layout.addWidget(self.comboLayouts)
+
+        self.comboLayouts.currentIndexChanged.connect(self.changeKBDLayout)
+        self.kbdWidget = KBDWidget(self, kbd)
+        self.layout.addWidget(self.kbdWidget)
+        self.comboLayouts.setCurrentIndex(0)
+        self.changeKBDLayout()
+
+    def changeKBDLayout(self):
+        show = self.comboLayouts.currentIndex()
+        hide = [ x for x in range(5) if x != show ]
+        list(map(lambda x: self.kbdWidget.hideLayout(x), hide))
+        self.kbdWidget.showLayout(show)
+
+
+
+class KBDTabs(QWidget):
+    def __init__(self, parent, kbds):
+        super(QWidget, self).__init__(parent)
+        self.layout = QVBoxLayout(self)
+        
+        # Initialize tab screen
+        self.tabs = QTabWidget()
+        # Add tabs
+        for i, kbd in enumerate(kbds):
+            self.tabs.addTab(KBDTab(self, kbd), f'Board {i}')
+        self.tabs.resize(300,200)
+        
+        # Add tabs to widget
+        self.layout.addWidget(self.tabs)
+        self.setLayout(self.layout)
+
+    @pyqtSlot()
+    def on_click(self):
+        print("\n")
+        for currentQTableWidgetItem in self.tableWidget.selectedItems():
+            print(currentQTableWidgetItem.row(), currentQTableWidgetItem.column(), currentQTableWidgetItem.text())
+
+class App(QMainWindow):
+
+    def __init__(self):
+        super().__init__()
+        self.title = 'Dumang Board Progamming Tool'
+        self.left = 0
+        self.top = 0
+        self.width = 500
+        self.height = 500
+        self.setWindowTitle(self.title)
+        self.setGeometry(self.left, self.top, self.width, self.height)
+        self.center()
+
+    def center(self):
+        screen = QApplication.desktop().screenNumber(QApplication.desktop().cursor().pos())
+        centerPoint = QApplication.desktop().screenGeometry(screen).center()
+        self.move(centerPoint - self.frameGeometry().center())
+
+
 def inspect_gui(kbd1, kbd2=None):
-    app = QApplication([])
-    window = QMainWindow()
-    central = QWidget()
-    layout = QVBoxLayout()
-
-    kbd1_label = QLabel("KBD: " + kbd1.serial)
-    layout.addWidget(kbd1_label)
-
-    kbd1_widget = KBDTableView(kbd1.configured_keys)
-    kbd1_widget.setMouseTracking(1)
-    kbd1_widget.itemEntered.connect(lambda item: kbd1_widget._on_itemEntered(kbd1, item))
-    kbd1_widget.itemExited.connect(lambda item: kbd1_widget._on_itemExited(kbd1, item))
-    layout.addWidget(kbd1_widget)
-
-    if kbd2:
-        kbd2_label = QLabel("KBD: " + kbd2.serial)
-        layout.addWidget(kbd2_label)
-
-        kbd2_widget = KBDTableView(kbd2.configured_keys)
-        kbd2_widget.setMouseTracking(1)
-        kbd2_widget.itemEntered.connect(lambda item: kbd2_widget._on_itemEntered(kbd2, item))
-        kbd2_widget.itemExited.connect(lambda item: kbd2_widget._on_itemExited(kbd2, item))
-        layout.addWidget(kbd2_widget)
-
-    central.setLayout(layout)
-
-    window.setCentralWidget(central)
-    window.show()
-    sys.exit(app.exec_())
+    init = QApplication([])
+    app = App()
+    kbds = [ kbd for kbd in [kbd1, kbd2] if kbd is not None ]
+    app.setCentralWidget(KBDTabs(app, kbds))
+    app.show()
+    sys.exit(init.exec_())

--- a/python/dumang_ctrl/tools/sync.py
+++ b/python/dumang_ctrl/tools/sync.py
@@ -90,18 +90,13 @@ def main():
     logger.info('Staring DuMang Layer Sync...')
     signal.signal(signal.SIGINT, signal_handler)
 
-    if sys.platform.startswith("linux"):
-        monitor = LinuxUSBConnectionMonitor(VENDOR_ID, PRODUCT_ID)
-    else:
-        # Does nothing.
-        monitor = USBConnectionMonitor(VENDOR_ID, PRODUCT_ID)
-
-    monitor.start()
-
+    monitor = USBConnectionMonitorRunner(VENDOR_ID, PRODUCT_ID)
     t = threading.Thread(target=device_init_thread, args=(monitor, ), daemon=True)
+    
+    monitor.start()
     t.start()
-    t.join()
 
+    t.join()
     monitor.join()
 
 if __name__ == "__main__":


### PR DESCRIPTION
# My experience
Tested this using macOS Catalina 10.15.6
As someone else mentioned, the sync doesn't seem to work, and I haven't tried using the `config.yml` as you explained.

Probably will come back to it later to at least try to help with something else.

I haven't had done anything similar but thanks for being so open and taking time to explaining it deeply.

This implements the change proposed in #1 
somewhat fixes #1 by using libusb's hotplug functionality

## Things included

### Keycodes added:
* [x] Layer 0/1/2/3
* [x] Layer Toggle 0/1/2/3
* [x] Key - Layer Toggle 0/1/2/3 (Short press: Output value Layer. Long Press: Layer Toggle

### New GUI:
Instead of showing all the layouts at the same time, there's a dropdown to select which layout to display.
Also, the use of tabs to differentiate between keyboards.

As you said:

> I'm new to GUI programming so don't expect anything fancy yet. This tool in general will require a bit more reverse engineering so stay tuned.

![Screen Shot 2020-08-28 at 22 41 30](https://user-images.githubusercontent.com/7953280/91628223-47a1e000-e983-11ea-8acc-f4d2706b176a.png)

![Screen Shot 2020-08-28 at 22 42 00](https://user-images.githubusercontent.com/7953280/91628226-54becf00-e983-11ea-8855-e66b8abbf887.png)
