### PR TITLE
Include dkm serial in a dump

### DIFF
--- a/dumang_ctrl/tools/config.py
+++ b/dumang_ctrl/tools/config.py
@@ -90,6 +90,8 @@ def main():
             cfg_yml['kbd_{}'.format(i)]['serial'] = kbd.serial
             for _, dkm in kbd.configured_keys.items():
                 cfg_key = cfg_yml['kbd_{}'.format(i)]['keys']['key_{}'.format(dkm.key)]
+                if dkm.serial is not None:
+                    cfg_key['serial'] = dkm.serial
                 for l, kc in dkm.layer_keycodes.items():
                     cfg_key['layer_{}'.format(l)] = str(kc)
                 if dkm.macro:


### PR DESCRIPTION
Unlike the key numbers (key_00 etc) which we use to index keys,
this number doesn't seem change even when a key module is moved to
a different board.

It's also useful to corralate with the output of other tool.
https://github.com/yamt/garbage/blob/f8b8a8e27eb3baa84fc57b33fb12c146e61e313c/dk6/dksync/syncer.c#L109